### PR TITLE
Only allow updates for packages not tracked in upstream

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -4,6 +4,13 @@ update_configs:
   - package_manager: "javascript"
     directory: "/frontend"
     update_schedule: "live"
+    allowed_updates:
+      - match:
+          dependency_name: "react-data-table-component*"
+      - match:
+          dependency_name: "react-datepicker"
+      - match:
+          dependency_name: "styled-components"
 
   - package_manager: "python"
     directory: "/"


### PR DESCRIPTION
This update adds the 3 packages that we have for the frontend that upstream does not have.

Note: We now need to make sure to maintain this list going forward until we have no difference with upstream at which point we can disable dependabot altogether.

Closes #155 