### PR TITLE
Fetch roads and corresponding images (if applicable)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@mapbox/mapbox-gl-draw": "^1.3.0",
     "@mapbox/mapbox-gl-geocoder": "^4.7.1",
     "@mapbox/mapbox-gl-language": "^0.10.1",
+    "@mapbox/tilebelt": "^1.0.2",
     "@reach/router": "^1.3.4",
     "@sentry/react": "^6.7.1",
     "@sentry/tracing": "^6.7.1",

--- a/frontend/src/components/taskSelection/map.js
+++ b/frontend/src/components/taskSelection/map.js
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useState } from 'react';
+import React, { useLayoutEffect, useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import bbox from '@turf/bbox';
 import mapboxgl from 'mapbox-gl';
@@ -10,6 +10,7 @@ import messages from './messages';
 import { MAPBOX_TOKEN, TASK_COLOURS, MAP_STYLE, MAPBOX_RTL_PLUGIN_URL } from '../../config';
 import lock from '../../assets/img/lock.png';
 import redlock from '../../assets/img/red-lock.png';
+import { getRoadHighwayImages } from '../../utils/getRoadHighwayImages';
 
 let lockIcon = new Image(17, 20);
 lockIcon.src = lock;
@@ -45,6 +46,14 @@ export const TasksMap = ({
   const [hoveredTaskId, setHoveredTaskId] = useState(null);
 
   const [map, setMapObj] = useState(null);
+  
+  useEffect(() => {
+    mapResults.features.slice(0, 10).map((feature) => { // TODO temporarily slice first 10 results due to Overpass API rate limit
+      const [x, y, z] = [feature.properties.taskX, feature.properties.taskY, feature.properties.taskZoom]
+      getRoadHighwayImages(x, y, z)
+    })
+  }, [])
+  
 
   useLayoutEffect(() => {
     /* May be able to refactor this to just take

--- a/frontend/src/utils/getRoadHighwayImages.js
+++ b/frontend/src/utils/getRoadHighwayImages.js
@@ -1,0 +1,43 @@
+import axios from 'axios'
+import tilebelt from "@mapbox/tilebelt"
+import { VectorTile } from '@mapbox/vector-tile';
+import Protobuf from 'pbf';
+
+export const getRoadHighwayImages = async (x, y, z) => {
+    /*
+    Searches individual tiles (MVT format) to see if it's a road, highway, or footpath. 
+    If it is, see if there are street view images taken.
+    Used to search for all rows in task grid
+    ---
+    tags:
+        - campaign
+    produces:
+        - array
+    parameters:
+        - name: x, y, z
+            in: header
+            description: x, y, and zoom level of task tile
+            required: true
+            type: integer
+    responses:
+        200:
+            description: Tiles and/or images fetched successfully
+        400:
+            description: Invalid Request or too many requests
+        500:
+            description: Internal Server Error
+    */
+    const bbox = tilebelt.tileToBBOX([x, y, z])
+    const url = `https://overpass-api.de/api/interpreter?data=[out:json][timeout:25];(node["highway"="footway"](${bbox[0]},${bbox[1]},${bbox[2]},${bbox[3]});way["highway"="footway"](${bbox[0]},${bbox[1]},${bbox[2]},${bbox[3]});relation["highway"="footway"](${bbox[0]},${bbox[1]},${bbox[2]},${bbox[3]}););out;>;out skel qt;`
+    const result = await axios.get(url);
+    if (result.data.elements.length > 0) { // if it's a road/highway/etc. fetch any images
+        const url = `https://tiles.mapillary.com/maps/vtp/mly1_public/2/${z}/${x}/${y}?access_token=MLY%7C5458526104199012%7Cc91f32db4e70dcd39a263dce9aa7f261`
+        axios.get(url, {
+        responseType: 'arraybuffer'
+        }).then(response => {
+            const protobuf = new Protobuf(new Uint8Array(response.data))
+            const tile = new VectorTile(protobuf)
+            return tile
+        })
+    }
+  };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2873,6 +2873,11 @@
   resolved "https://registry.npmjs.org/@mapbox/sphericalmercator/-/sphericalmercator-1.1.0.tgz"
   integrity sha512-pEsfZyG4OMThlfFQbCte4gegvHUjxXCjz0KZ4Xk8NdOYTQBLflj6U8PL05RPAiuRAMAQNUUKJuL6qYZ5Y4kAWA==
 
+"@mapbox/tilebelt@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@mapbox/tilebelt/-/tilebelt-1.0.2.tgz#32936c3acad3ea3e669bb083a598bcc7d74b4ec9"
+  integrity sha512-tGJN2VIgWrXqBTPIxFVklklIpcy6ss8W5ouq+cjNLXPXFraRaDR4Ice+5Q8/uLX+6aH23lWBMydOIn8PcdVcpA==
+
 "@mapbox/tiny-sdf@^1.1.1":
   version "1.1.1"
   resolved "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.1.1.tgz"


### PR DESCRIPTION
# Changelog
- map.js now fetches roads/highways via the Overpass API in task grids
- if a road is found, Mapillary API will be queried to see if there are any corresponding street view images.

# Known bugs
- Currently not an efficient way to pull all tasks in grid due to Overpass rate limits